### PR TITLE
Bump up uuid version to `^4.2.1`

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  uuid: ^3.0.6
+  uuid: ^4.2.1
   equatable: ^2.0.0
 
 dev_dependencies:


### PR DESCRIPTION
Thanks for the package and the work done on it :)

This PR is simply to bump up the version of `uuid` package to `^4.2.1` as other packages depend on it and it's causing conflicts when depending on both `flutter_dialog_queue` and other packages.